### PR TITLE
tree enclosed in individually scrolling bounder

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -60,10 +60,10 @@ const App: React.FC = (): JSX.Element => {
         </span>
       </div>
       <div
-        className={classes.AppContentBounder}
+        className={classes.TreeBounder}
         style={{ top: topItemsRef.current?.offsetHeight }}
       >
-        <div className={classes.AppContent}>
+        <div className={classes.Tree}>
           <ArcherContainer
             arrowLength={0}
             style={{ zIndex: 1 }}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
 import { IconButton } from '@material-ui/core'
 import { Redo, Undo } from '@material-ui/icons'
-import React, { useReducer, useState } from 'react'
+import React, { useReducer, useState, useRef } from 'react'
 
 import {
   createTree,
@@ -14,6 +14,7 @@ import NodeView from './NodeView'
 import PremiseInput from './PremiseInput'
 import PremisesSelector from './PremisesSelector'
 import { ArcherContainer } from 'react-archer'
+import appJSS from '../styles/App_styles'
 
 const App: React.FC = (): JSX.Element => {
   const [premises, setPremises] = useState(initialPremises)
@@ -26,49 +27,59 @@ const App: React.FC = (): JSX.Element => {
     const premiseArray = rawInput.split(',')
     dispatch(createTree(premiseArray))
   }
-
+  const classes = appJSS()
+  const topItemsRef = useRef<HTMLDivElement>(null)
   return (
-    <main className="App">
-      <PremisesSelector onChange={handleSubmitPremises} />
-      <PremiseInput
-        premises={premises}
-        onSubmit={handleSubmitPremises}
-        setPremises={setPremises}
-      />
-      <span className="tree-buttons">
-        <IconButton
-          className="undo-button"
-          onClick={() => {
-            dispatch({ type: 'UNDO' })
-          }}
-          disabled={!pastStates.length}
-        >
-          <Undo />
-        </IconButton>
-        <IconButton
-          className="redo-button"
-          onClick={() => {
-            dispatch({ type: 'REDO' })
-          }}
-          disabled={!futureStates.length}
-        >
-          <Redo />
-        </IconButton>
-      </span>
-      <ArcherContainer
-        arrowLength={0}
-        style={{ zIndex: 1 }}
-        svgContainerStyle={{ zIndex: -1 }}
-        strokeColor="black"
-        noCurves={false}
-      >
-        <NodeView
-          node={currentState.tree}
-          dispatch={dispatch}
-          justifications={currentState.justifications}
-          feedbackMap={currentState.feedback.feedback}
+    <main className={classes.AppBounder}>
+      <div className={classes.TopItemsBounder} ref={topItemsRef}>
+        <PremisesSelector onChange={handleSubmitPremises} />
+        <PremiseInput
+          premises={premises}
+          onSubmit={handleSubmitPremises}
+          setPremises={setPremises}
         />
-      </ArcherContainer>
+        <span className="tree-buttons">
+          <IconButton
+            className="undo-button"
+            onClick={() => {
+              dispatch({ type: 'UNDO' })
+            }}
+            disabled={!pastStates.length}
+          >
+            <Undo />
+          </IconButton>
+          <IconButton
+            className="redo-button"
+            onClick={() => {
+              dispatch({ type: 'REDO' })
+            }}
+            disabled={!futureStates.length}
+          >
+            <Redo />
+          </IconButton>
+        </span>
+      </div>
+      <div
+        className={classes.AppContentBounder}
+        style={{ top: topItemsRef.current?.offsetHeight }}
+      >
+        <div className={classes.AppContent}>
+          <ArcherContainer
+            arrowLength={0}
+            style={{ zIndex: 1 }}
+            svgContainerStyle={{ zIndex: -1 }}
+            strokeColor="black"
+            noCurves={false}
+          >
+            <NodeView
+              node={currentState.tree}
+              dispatch={dispatch}
+              justifications={currentState.justifications}
+              feedbackMap={currentState.feedback.feedback}
+            />
+          </ArcherContainer>
+        </div>
+      </div>
       <JSONView {...{ ...currentState, dispatch }} />
     </main>
   )

--- a/src/components/JSONView.tsx
+++ b/src/components/JSONView.tsx
@@ -2,7 +2,7 @@ import { TextareaAutosize } from '@material-ui/core'
 import React, { FC, useEffect, useState } from 'react'
 
 import { CustomDispatch, RudolfStore, updateFeedback } from '../RudolfReducer'
-import useJSS from './JSONView_styles'
+import jsonviewJSS from '../styles/JSONView_styles'
 import { checkTree } from '../util/carnapAdapter'
 
 export const JSONView: FC<RudolfStore & { dispatch: CustomDispatch }> = ({
@@ -22,7 +22,7 @@ export const JSONView: FC<RudolfStore & { dispatch: CustomDispatch }> = ({
         })
     }
   }, [dispatch, justifications, tree])
-  const classes = useJSS()
+  const classes = jsonviewJSS()
   const [open, setOpen] = useState(false)
   return (
     <div className={classes.Bounder}>

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -1,15 +1,3 @@
-main.App {
-  background: #ffffff;
-  text-align: center;
-  color: black;
-  // min-height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  font-size: calc(10px + 2vmin);
-}
-
 button.submit-premises {
   font-family: Book Antiqua, serif;
   margin-left: 8px;

--- a/src/styles/App_styles.ts
+++ b/src/styles/App_styles.ts
@@ -20,7 +20,7 @@ const appJSS = createUseStyles({
     alignItems: 'center',
   },
 
-  AppContentBounder: {
+  TreeBounder: {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -39,7 +39,7 @@ const appJSS = createUseStyles({
     },
   },
 
-  AppContent: {
+  Tree: {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',

--- a/src/styles/App_styles.ts
+++ b/src/styles/App_styles.ts
@@ -1,0 +1,52 @@
+import { createUseStyles } from 'react-jss'
+
+const appJSS = createUseStyles({
+  AppBounder: {
+    background: '#ffffff',
+    textAlign: 'center',
+    color: 'black',
+    fontSize: 'calc(10px + 2vmin)',
+    width: '100vw',
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+
+  TopItemsBounder: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+
+  AppContentBounder: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    width: '80vw',
+    height: '70vh',
+    position: 'absolute',
+    borderColor: 'black',
+    borderStyle: 'solid',
+    overflow: 'scroll',
+    '&::-webkit-scrollbar': {
+      height: '6px',
+      width: '6px',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: 'black',
+    },
+  },
+
+  AppContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    position: 'absolute',
+    left: '50%',
+    transform: 'translate(max(-50%, -40vw), 0px)',
+  },
+})
+
+export default appJSS

--- a/src/styles/JSONView_styles.ts
+++ b/src/styles/JSONView_styles.ts
@@ -1,6 +1,6 @@
 import { createUseStyles } from 'react-jss'
 
-const useJSS = createUseStyles({
+const jsonviewJSS = createUseStyles({
   Bounder: {
     minWidth: '100%',
     position: 'fixed',
@@ -27,4 +27,4 @@ const useJSS = createUseStyles({
   },
 })
 
-export default useJSS
+export default jsonviewJSS


### PR DESCRIPTION
fixes #69. The fix I implemented involved using position: absolute on the content div and positioning it based on its size. The key was to make sure there was never any overflow on the left (divs can only scroll overflow in one direction), so if the displacement of centering the content is greater than 50% of the width of the parent bounding div, the tree is placed at left: 0 so that it does not overflow.

This is still not ideal in that when a tree begins to overflow, it repositions itself to be left-aligned. If you play around with it you will see what I mean. Let me know any thoughts.


<img width="911" alt="Annotation 2020-07-17 133526" src="https://user-images.githubusercontent.com/49575486/87828733-6b292500-c832-11ea-8d30-d9109ef83e51.png">
