### PR TITLE
position set to static if topItemsRef.current is undefined

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -63,7 +63,10 @@ const App: React.FC = (): JSX.Element => {
       </div>
       <div
         className={classes.TreeBounder}
-        style={{ top: topItemsRef.current?.offsetHeight }}
+        style={{
+          top: topItemsRef.current?.offsetHeight,
+          position: topItemsRef.current ? 'absolute' : 'static',
+        }}
       >
         <div className={classes.Tree}>
           <ArcherContainer


### PR DESCRIPTION
I realized there was actually this trivial fix. Initially rendering tree's position: 'static' places the tree following the flow of the flexbox, which is fine initially when the tree does not overflow. Subsequent interaction causes the ref.current to become defined, so positioning will switch to absolute, as is needed for scrolling to work correctly